### PR TITLE
camera: Workaround for GCC-compiled HAL3 drivers

### DIFF
--- a/camera/CameraMetadata.cpp
+++ b/camera/CameraMetadata.cpp
@@ -33,22 +33,22 @@ typedef Parcel::WritableBlob WritableBlob;
 typedef Parcel::ReadableBlob ReadableBlob;
 
 CameraMetadata::CameraMetadata() :
-        mBuffer(NULL), mLocked(false) {
+        mBuffer(NULL), mReserved(false), mLocked(false) {
 }
 
 CameraMetadata::CameraMetadata(size_t entryCapacity, size_t dataCapacity) :
-        mLocked(false)
+        mReserved(false), mLocked(false)
 {
     mBuffer = allocate_camera_metadata(entryCapacity, dataCapacity);
 }
 
 CameraMetadata::CameraMetadata(const CameraMetadata &other) :
-        mLocked(false) {
+        mReserved(false), mLocked(false) {
     mBuffer = clone_camera_metadata(other.mBuffer);
 }
 
 CameraMetadata::CameraMetadata(camera_metadata_t *buffer) :
-        mBuffer(NULL), mLocked(false) {
+        mBuffer(NULL), mReserved(false), mLocked(false) {
     acquire(buffer);
 }
 

--- a/camera/include/camera/CameraMetadata.h
+++ b/camera/include/camera/CameraMetadata.h
@@ -222,6 +222,7 @@ class CameraMetadata: public Parcelable {
 
   private:
     camera_metadata_t *mBuffer;
+    volatile bool      mReserved;
     mutable bool       mLocked;
 
     /**


### PR DESCRIPTION
 * When starting HAL3 using an older camera library (blob),
   the internal structure is aligned differently when compiled
   with GCC vs. LLVM. This could cause the "mLocked" field to
   be overwritten unintentionally, resulting in all update()
   calls from the HAL failing with "CameraMetadata is locked"
   even though nothing actually locked it! This would cause
   the service to kick out the HAL, and nobody gets a camera.
 * Cheap fix is to add a padding byte between mBuffer and
   mLocked, and we are back in business.

Change-Id: I3306e14867007a90885aca13e238dee5b49d8da2
Signed-off-by: Corey Edwards <ensabahnur16@gmail.com>